### PR TITLE
Upgrade to laravel 6 and laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0",
-        "ixudra/translation": "~5.3"
+        "illuminate/support": "~5.0|~6.0",
+        "ixudra/translation": "~5.3|~5.4"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0|~6.0",
+        "illuminate/support": "~5.0|~6.0|~7.0",
         "ixudra/translation": "~5.3|~5.4"
     },
 


### PR DESCRIPTION
Allow illuminate `~7.0` dependencies
**NOTE**: depends on `ixudra/translation` this package should have a new release supporting Laravel 7 first. The package version should be updated in this package as well in order to work.

Fixes #1 